### PR TITLE
renovate-configure-branch-name-fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ try {
     
     // const branch = /[^/]*$/.exec(GITHUB_REF)[0]  //GITHUB_REF out of process.env
     // core.info(branch)
-    const branchName = GITHUB_HEAD_REF || GITHUB_REF_NAME
+    const branchName = (GITHUB_HEAD_REF || GITHUB_REF_NAME).replace(/\//g, '-')
     core.info(branchName)
     core.info(releaseBranch)
     if (branchName == releaseBranch)


### PR DESCRIPTION
renovate/configure (branch name for bot) is causing issues merging into main